### PR TITLE
Switch to v2 of the Instance Metadata Service API

### DIFF
--- a/modules/bash-commons/src/aws.sh
+++ b/modules/bash-commons/src/aws.sh
@@ -11,16 +11,26 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/assert.sh"
 # shellcheck source=./modules/bash-commons/src/log.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/log.sh"
 
+function aws_get_api_token {
+  curl --silent -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"
+}
+
 # Look up the given path in the EC2 Instance metadata endpoint
 function aws_lookup_path_in_instance_metadata {
   local -r path="$1"
-  curl --silent --show-error --location "http://169.254.169.254/latest/meta-data/$path/"
+
+  local token
+  token="$(aws_get_api_token)"
+  curl --silent --show-error --location "http://169.254.169.254/latest/meta-data/$path/" -H "X-aws-ec2-metadata-token: $token"
 }
 
 # Look up the given path in the EC2 Instance dynamic metadata endpoint
 function aws_lookup_path_in_instance_dynamic_data {
   local -r path="$1"
-  curl --silent --show-error --location "http://169.254.169.254/latest/dynamic/$path/"
+
+  local token
+  token="$(aws_get_api_token)"
+  curl --silent --show-error --location "http://169.254.169.254/latest/dynamic/$path/" -H "X-aws-ec2-metadata-token: $token"
 }
 
 # Get the private IP address for this EC2 Instance

--- a/test/aws-ec2-metadata.bats
+++ b/test/aws-ec2-metadata.bats
@@ -4,6 +4,7 @@ source "$BATS_TEST_DIRNAME/../modules/bash-commons/src/aws.sh"
 load "test-helper"
 load "aws-helper"
 
+readonly api_token="AQAEAArLzfm8TnzVoAFYcAnoJEyfLlx8itHCZvI9AY_OfCFiaYNK2w=="
 readonly local_ipv4="11.22.33.44"
 readonly public_ipv4="55.66.77.88"
 readonly local_hostname="ip-10-251-50-12.ec2.internal"
@@ -14,6 +15,7 @@ readonly availability_zone="${mock_region}b"
 
 function setup {
   start_ec2_metadata_mock \
+    "$api_token" \
     "$local_ipv4" \
     "$public_ipv4" \
     "$local_hostname" \
@@ -25,6 +27,12 @@ function setup {
 
 function teardown {
   stop_ec2_metadata_mock
+}
+
+@test "aws_get_api_token" {
+  run aws_get_api_token
+  assert_success
+  assert_output "$api_token"
 }
 
 @test "aws_get_instance_private_ip" {

--- a/test/aws-helper.bash
+++ b/test/aws-helper.bash
@@ -14,13 +14,14 @@ readonly EC2_METADATA_MOCK_LOG_FILE_PATH="$EC2_METADATA_MOCK_TMP_DIR/ec2-metadat
 
 function start_ec2_metadata_mock {
   # Set env vars for ec2-metadata-mock
-  export meta_data_local_ipv4="$1"
-  export meta_data_public_ipv4="$2"
-  export meta_data_local_hostname="$3"
-  export meta_data_public_hostname="$4"
-  export meta_data_instance_id="$5"
-  local readonly region="$6"
-  export meta_data_placement__availability_zone="$7"
+  export api_token="$1"
+  export meta_data_local_ipv4="$2"
+  export meta_data_public_ipv4="$3"
+  export meta_data_local_hostname="$4"
+  export meta_data_public_hostname="$5"
+  export meta_data_instance_id="$6"
+  local readonly region="$7"
+  export meta_data_placement__availability_zone="$8"
   export dynamic_data_instance_identity__document=$(cat <<END_HEREDOC
 {
   "devpayProductCodes" : null,

--- a/test/aws-mock/aws.sh
+++ b/test/aws-mock/aws.sh
@@ -4,6 +4,11 @@
 
 set -e
 
+# Get a API session token
+function aws_get_api_token {
+  echo -n "AQAEAArLzfm8TnzVoAFYcAnoJEyfLlx8itHCZvI9AY_OfCFiaYNK2w=="
+}
+
 # Get the private IP address for this EC2 Instance
 function aws_get_instance_private_ip {
   echo -n "11.22.33.44"

--- a/test/ec2-metadata-mock/ec2-metadata-mock.py
+++ b/test/ec2-metadata-mock/ec2-metadata-mock.py
@@ -13,8 +13,13 @@ from flask import Flask
 
 app = Flask(__name__)
 
+API_ENV_VAR_PREFIX = 'api'
 META_DATA_ENV_VAR_PREFIX = 'meta_data'
 DYNAMIC_DATA_ENV_VAR_PREFIX = 'dynamic_data'
+
+@app.route("/latest/api/<path:path>", methods=['PUT'])
+def api():
+    return lookup_path(path, API_ENV_VAR_PREFIX)
 
 @app.route("/latest/meta-data/<path:path>")
 def meta_data(path):


### PR DESCRIPTION
Update all calls to use IMDSv2[1] which is a session-based rather than just
simple request-response. This requires 2 changes:

- Obtaining a session token from `/latest/api/token`
- Passing this token in a `X-aws-ec2-metadata-token` header when making
requests.

IMDSv2 is enabled by default and AWS Foundation Security Best Practices
recommends v1 not be used due to a number of potential security
vulnerabilities[2].

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html
[2] https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#fsbp-ec2-8